### PR TITLE
Updated build image to use latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   backup:
     docker:
-      - image: farmsmart/gcp-firebase:1.0.0
+      - image: farmsmart/gcp-firebase:latest
     steps:
       - checkout
       - run: |

--- a/Dockerfiles/gcp-firebase/1.0.0/Dockerfile
+++ b/Dockerfiles/gcp-firebase/1.0.0/Dockerfile
@@ -1,6 +1,0 @@
-FROM google/cloud-sdk:241.0.0
-
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-       && apt-get install -y nodejs
-
-RUN npm install -g firebase-tools@7.0.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The backup bucket is in the same project and should be named <google_project_id>
 
 ## Import
 
-Currently the import is a manual process which requires firebase SDK and the google cloud SDK. There is a docker image which has these dependencies installed - farmsmart/gcp-firebase:1.0.0
+Currently the import is a manual process which requires firebase SDK and the google cloud SDK. There is a docker image which has these dependencies installed - farmsmart/gcp-firebase
 
 `backup/firebase-import.sh ${credential_file} ${firebase_token} ${project} ${date}`
 


### PR DESCRIPTION
Fix for the endless loop caused by a bug in the auth:export command for firebase-tools SDK

The issue is caused by a known bug with the firebase SDK: https://github.com/firebase/firebase-tools/issues/1643

  There is a fix in the latest version: https://github.com/firebase/firebase-tools/pull/1642

This updates the build to use the latest docker image which contains the fix